### PR TITLE
Add support for deserializing compressed data

### DIFF
--- a/lib/c.js
+++ b/lib/c.js
@@ -1,3 +1,4 @@
+// 2014.10.30 [GMelika] Add support for compressed streams
 // 2014.03.18 Serialize date now adjusts for timezone.
 // 2013.04.29 Dict decodes to map, except for keyed tables.
 // 2013.02.13 Keyed tables were not being decoded correctly.
@@ -9,8 +10,57 @@
 // ws.onmessage=function(e){var arrayBuffer=e.data;if(arrayBuffer){var v=deserialize(arrayBuffer);...
 // note ws.binaryType = 'arraybuffer';
 
-function deserialize(x){
-  var a=x[0],pos=8,j2p32=Math.pow(2,32),ub=new Uint8Array(x),sb=new Int8Array(x),bb=new Uint8Array(8),hb=new Int16Array(bb.buffer),ib=new Int32Array(bb.buffer),eb=new Float32Array(bb.buffer),fb=new Float64Array(bb.buffer);
+  function deserialize(x){
+  var a=x[0],pos=8,j2p32=Math.pow(2,32),ub,sb,
+    bb=new Uint8Array(8),hb=new Int16Array(bb.buffer),
+    ib=new Int32Array(bb.buffer),eb=new Float32Array(bb.buffer),
+    fb=new Float64Array(bb.buffer);
+  var isCompressed = x[2]==1;
+  var compressedSize = 0;
+  if(isCompressed) {
+    u();
+  } else {
+    ub=new Uint8Array(x);
+    sb=new Int8Array(x);
+  }
+  function u(){
+    var n=0,r=0,f=0,s=8,p=s,i=0;
+    var compressedSize = rInt32();
+    var dst=new Buffer(compressedSize);
+    var d=12;
+    var aa=new Int32Array(256);
+    b = x;
+    while(s<dst.length){
+      if(!i) {
+        f=b[d++];
+        // console.log(d-1,b[d-1],f);
+        i=1;
+      }
+      if(f&i) {
+        r=aa[b[d++]];
+        dst[s++]=dst[r++];
+        dst[s++]=dst[r++];
+        n=0xff&b[d++];
+        for(var m=0;m<n;m++)
+          dst[s+m]=dst[r+m];
+      } else {
+        dst[s++]=b[d++];
+      }
+      while(p<(s-1)) {
+        aa[dst[p]^dst[p+1]]=p++;
+      }
+      if(f&i) {
+        p=(s+=n);
+      }
+      i*=2;
+      if(i==256) {
+        i=0;
+      }
+    }
+    x=dst;pos=8;
+    sb=new Int8Array(x);
+    ub=new Uint8Array(x);
+  }
   function rBool(){return rInt8()==1;}
   function rChar(){return String.fromCharCode(rInt8());}
   function rInt8(){return sb[pos++];}
@@ -22,7 +72,7 @@ function deserialize(x){
   function rInt64(){rNUInt8(8);var x=ib[1],y=ib[0];return x*j2p32+(y>=0?y:j2p32+y);}// closest number to 64 bit int...
   function rFloat32(){rNUInt8(4);return eb[0];}
   function rFloat64(){rNUInt8(8);return fb[0];}
-  function rSymbol(){var i=pos,c,s="";for(;(c=rInt8())!==0;s+=String.fromCharCode(c));return s;};
+  function rSymbol(){var i=pos,c,s="";for(;(c=rInt8())!==0;s+=String.fromCharCode(c));return s;}
   function rTimestamp(){return date(rInt64()/86400000000000);}
   function rMonth(){var y=rInt32();var m=y%12;y=2000+y/12;return new Date(Date.UTC(y,m,01));}
   function date(n){return new Date(86400000*(10957+n));}
@@ -33,7 +83,10 @@ function deserialize(x){
   function rMinute(){return date(rInt32()/1440);}
   function rTime(){return date(rInt32()/86400000);}
   function r(){
-    var fns=[r,rBool,rGuid,null,rUInt8,rInt16,rInt32,rInt64,rFloat32,rFloat64,rChar,rSymbol,rTimestamp,rMonth,rDate,rDateTime,rTimespan,rMinute,rSecond,rTime];
+    var fns=[r,
+      rBool,rGuid,null,rUInt8,rInt16,rInt32,rInt64,rFloat32,rFloat64,rChar,
+      rSymbol,rTimestamp,rMonth,rDate,rDateTime,rTimespan,rMinute,rSecond,rTime
+    ];
     var i=0,n,t=rInt8();
     if(t<0&&t>-20)return fns[-t]();
     if(t>99){
@@ -46,10 +99,10 @@ function deserialize(x){
       var flip=98==ub[pos],x=r(),y=r(),o;
       if(!flip){
         o={};
-        for(var i=0;i<x.length;i++)
+        for(i=0;i<x.length;i++)
           o[x[i]]=y[i];
       }else
-        o=new Array(2),o[0]=x,o[1]=y;
+        o=new Array(2);o[0]=x;o[1]=y;
       return o;
     }
     pos++;
@@ -57,7 +110,8 @@ function deserialize(x){
  //    return r(); // better as array of dicts?
       rInt8(); // check type is 99 here
     // read the arrays and then flip them into an array of dicts
-      var x=r(),y=r();
+      var x=r();
+      var y=r();
       var A=new Array(y[0].length);
       for(var j=0;j<y[0].length;j++){
         var o={};


### PR DESCRIPTION
The original c.js library has no support for deserializing compressed streams, so I added code to decompress the stream first before parsing
