### PR TITLE
Add possibility to listen to a handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ con.ks("show", [1, 2, 3], function(err) {
 });
 ```
 
+### Listen to a handle
+
+```javascript
+con.k(function(err, res) {
+	if (err) throw err;
+	console.log('result'm res);
+});
+```
+
 ### Subscribe to kdb+tick
 
 ```javascript


### PR DESCRIPTION
Hi, node-q is looking great! 

However I noticed that it was not possible to listen on a handle as you can in q:

- `h[];` if `h` is your handle

I needed this feature for my application so I added it and I thought I would make a pull request.

Let me know if there is any problem.
Cheers