### PR TITLE
Replace null char with empty string in symbols

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -146,8 +146,8 @@ exports.symbol = function(string) {
   "use strict";
   if (string !== null) {
     assert.string(string, "string");
+    string = string.replace(/\u0000/g, "");
   }
-  string = string.replace(/\u0000/g, "");
   return new Typed("symbol", string);
 };
 exports.symbols = function(strings) {

--- a/lib/typed.js
+++ b/lib/typed.js
@@ -147,6 +147,7 @@ exports.symbol = function(string) {
   if (string !== null) {
     assert.string(string, "string");
   }
+  string = string.replace(/\u0000/g, "");
   return new Typed("symbol", string);
 };
 exports.symbols = function(strings) {


### PR DESCRIPTION
A very simple fix for issue 43 in which strings containing the null character `\u0000` can cause a corrupt message to be sent to the q process. This fix silently removes the null character from symbols, which I have confirmed with a consultant from Kx is actually an illegal character in a symbol.

The Java implementation of the serialiser apparently truncates at the first occurence of the null character which in my opinion is less desirable, since the expected result in most real world scenarios is that the string continues to look the same as it did before, hence replace.

This is my first ever pull request so not sure if I've done it correctly, but by all means change as you see fit or reject if you don't think it's the responsibility of this library to guard against this scenario (or you think the change should be applied at the `c.js` level).