### PR TITLE
Added ability to contact KDB with Unix Domain Sockets rather than TCP

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -61,5 +61,5 @@
 	"yui"           : false,
 	"globals"       : {},
 	"predef"        : ["describe", "it", "before", "after"],
-    "esversion"     : 6
+        "esversion"     : 6
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -60,6 +60,5 @@
 	"wsh"           : false,
 	"yui"           : false,
 	"globals"       : {},
-	"predef"        : ["describe", "it", "before", "after"],
-        "esversion"     : 6
+	"predef"        : ["describe", "it", "before", "after"]
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -60,5 +60,6 @@
 	"wsh"           : false,
 	"yui"           : false,
 	"globals"       : {},
-	"predef"        : ["describe", "it", "before", "after"]
+	"predef"        : ["describe", "it", "before", "after"],
+    "esversion"     : 6
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nodeq.connect({host: "localhost", port: 5000}, function(err, con) {
 });
 ```
 
-#### Create Connection with user and password auth
+### Create Connection with user and password auth
 
 ```javascript
 var nodeq = require("node-q");
@@ -33,6 +33,15 @@ nodeq.connect({host: "localhost", port: 5000, user: "user", password: "password"
 	if (err) throw err;
 	console.log("connected");
 	// interact with con like demonstrated below
+});
+```
+
+### Create Connection with Unix Domain Socket (Doesn't support abstract namespace sockets: KDB 3.5+ on Linux)
+
+```javascript
+nodeq.connect({ unixSocket: "/path/to/socket" }, function(err, con) {
+	if (err) throw err;
+	console.log("connected");
 });
 ```
 
@@ -260,8 +269,9 @@ For every primitive type in q, this module exports a method to wrap the JavaScri
 ### connect(params, cb)
 
 * `params`: Object
-	* `host`: String (e. g. "localhost")
-	* `port`: Number (e. g. 5000)
+	* `host`: String (e. g. "localhost") (optional)
+	* `port`: Number (e. g. 5000) (optional)
+	* `unixSocket`: String (e. g. "/path/to/socket") (optional)
 	* `user`: String (optional)
 	* `password`: String (optional)
 	* `socketNoDelay` : Boolean (optional, see http://nodejs.org/api/net.html#net_socket_setnodelay_nodelay)

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,11 +162,11 @@ export declare interface ConnectionParameters {
   /**
    * The KDB host to connect to.
    */
-  host: string;
+  host?: string;
   /**
    * The port on the KDB host to connect to.
    */
-  port: number;
+  port?: number;
   /**
    * Optional - The user to authenticate as to KDB.
    */
@@ -200,6 +200,10 @@ export declare interface ConnectionParameters {
    * Specifying false will cause KDB longs to be returned using long.js.
    */
   long2number?: boolean;
+  /**
+   * Connect with Unix Domain Sockets rather than TCP
+   */
+  unixSocket?: string;
 }
 
 /**
@@ -216,7 +220,7 @@ export declare function connect(parameters: ConnectionParameters, callback: Asyn
  */
 export declare function connect(host: string, port: number, callback: AsyncValueCallback<Connection>): void;
 /**
- * Attempt to connect to aKDB instance using the specified host, port, username and password, and return the connection when it is established.
+ * Attempt to connect to a KDB instance using the specified host, port, username and password, and return the connection when it is established.
  * @param host The KDB host to connect to.
  * @param port The port on the host to connect to.
  * @param user The user to authenticate to KDB with.
@@ -224,6 +228,12 @@ export declare function connect(host: string, port: number, callback: AsyncValue
  * @param callback Callback to be invoked when the connection is (or fails to be) established.
  */
 export declare function connect(host: string, port: number, user: string, password: string, callback: AsyncValueCallback<Connection>): void;
+/**
+ * Attempt to connect to KDB using Unix Domain Sockets, and return the connection when it is established.
+ * @param unixSocket Path to KDB Unix Domain Socket (Doesn't support abstract namespace sockets: KDB3.5+ on Linux)
+ * @param callback Callback to be invoked when the connection is (or fails to be) established.
+ */
+export declare function connect(unixSocket: string, callback: AsyncValueCallback<Connection>): void;
 /**
  * Brings in the Typed wrapper APIs.
  */

--- a/index.js
+++ b/index.js
@@ -189,8 +189,8 @@ function connect(params, cb) {
 		}
 	}
 	assert.object(params, "params");
-	assert.string(params.host, "params.host");
-	assert.number(params.port, "params.port");
+	assert.optionalString(params.host, "params.host");
+	assert.optionalNumber(params.port, "params.port");
 	assert.optionalString(params.user, "params.user");
 	assert.optionalString(params.password, "password");
 	assert.optionalBool(params.socketNoDelay, "params.socketNoDelay");
@@ -199,6 +199,7 @@ function connect(params, cb) {
 	assert.optionalBool(params.flipTables, "params.flipTables");
 	assert.optionalBool(params.emptyChar2null, "params.emptyChar2null");
 	assert.optionalBool(params.long2number, "params.long2number");
+	assert.optionalString(params.unixSocket, "params.unixSocket");
 	if (params.user !== undefined) {
 		assert.string(params.password, "password");
 		auth = params.user + ":" + params.password;
@@ -214,7 +215,16 @@ function connect(params, cb) {
 		close = true;
 		cb(new Error("Connection closes (wrong auth?)"));
 	};
-	socket = net.connect(params.port, params.host, function() {
+
+	let socketArgs = [];
+	if (params.unixSocket) {
+		socketArgs.push(params.unixSocket);
+	}
+	else {
+		socketArgs.push(params.port, params.host);
+	}
+
+	socket = net.connect(...socketArgs, function() {
 		socket.removeListener("error", errorcb);
 		if (error === false) {
 			socket.once("close", closecb);

--- a/index.js
+++ b/index.js
@@ -215,16 +215,14 @@ function connect(params, cb) {
 		close = true;
 		cb(new Error("Connection closes (wrong auth?)"));
 	};
-
-	let socketArgs = [];
+	var socketArgs = [];
 	if (params.unixSocket) {
 		socketArgs.push(params.unixSocket);
 	}
 	else {
 		socketArgs.push(params.port, params.host);
 	}
-
-	socket = net.connect(...socketArgs, function() {
+	socketArgs.push(function() {
 		socket.removeListener("error", errorcb);
 		if (error === false) {
 			socket.once("close", closecb);
@@ -237,6 +235,7 @@ function connect(params, cb) {
 			});
 		}
 	});
+	socket = net.connect.apply(null, socketArgs);
 	if (params.socketTimeout !== undefined) {
 		socket.setTimeout(params.socketTimeout);
 	}


### PR DESCRIPTION
Unix Domain Sockets allow for better performance than TCP and is preferable if node-q is being utilized on the same machine as the KDB/Q server. Changes don't work with KDB 3.5+ on Linux as it utilizes the abstract namespace for Unix Domain Sockets and the "net" module doesn't support connecting to those sockets (there is a module called "abstract-socket" that adds this support). This will work on older versions of KDB and on MacOS.

Connecting by TCP still works the same as before. Below code is for connecting by Unix Domain Sockets, also supports authentication with username and password.

```js
nodeq.connect({ unixSocket: "/path/to/socket" }, function(err, con) {
	if (err) throw err;
	console.log("connected");
});
```
