### PR TITLE
Fix TS issue TS2688/TS2304

### DIFF
--- a/lib/typed.d.ts
+++ b/lib/typed.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="long" />
-
 /**
  * Explicit serialization to KDB is possible using the Typed API.
  */
@@ -53,7 +51,7 @@ export declare function int(value: number): Typed;
  * Explicitly wrap the specified value as a long.
  * @param value The value to wrap.
  */
-export declare function long(value: Long): Typed;
+export declare function long(value: number): Typed;
 /**
  * Explicitly wrap the specified value as a real.
  * @param value The value to wrap.
@@ -146,7 +144,7 @@ export declare function ints(value: number[] | ReadonlyArray<number>): Typed;
  * Explicitly wrap the specified array as a typed list of longs.
  * @param value The array to wrap.
  */
-export declare function longs(value: Long[] | ReadonlyArray<Long>): Typed;
+export declare function longs(value: number[] | ReadonlyArray<number>): Typed;
 /**
  * Explicitly wrap the specified array as a typed list of reals.
  * @param value The array to wrap.


### PR DESCRIPTION
### Issue

When trying to compile a Typescript project that use `node-q` module, I get these error:
- typed.d.ts, line 1: "error: TS2688: cannot find type definition for 'long'"
- typed.d.ts, line 56: "error: TS2304: cannot find name 'Long'"
- typed.d.ts, line 149: "error: TS2304: cannot find name 'Long'"
- typed.d.ts, line 149: "error: TS2304: cannot find name 'Long'"

### fix

Remove references to Long that does not exist in TypeScript;
usenumber instead