### PR TITLE
Add support for TLS socket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ If you have a kdb+tick setup please also run `make mochait`.
 
 ### Integration Test
 
-Assumes a running q process on port 5000 with kdb+tick available in QHOME (`QHOME=~/q ~/q/m32/q -p 5000`)
+Assumes a running q process on port 5000 with kdb+tick available in QHOME (`QHOME=~/q ~/q/m32/q -p 5000`). For the tls tests you will also need a running q process on port 6000 set up to require tls. Instructions for this can be found [here](https://code.kx.com/q/kb/ssl/). If you are using a self signed certificate you will also need to set the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0`.
 
 	make mochait
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ nodeq.connect({host: "localhost", port: 5000}, function(err, con) {
 });
 ```
 
+### Create TLS Connection
+
+```javascript
+var nodeq = require("node-q");
+nodeq.connect({host: "localhost", port: 6000, useTLS: true}, function(err, con) {
+	if (err) throw err;
+	console.log("connected");
+	// interact with con like demonstrated below
+});
+```
+
 ### Create Connection with user and password auth
 
 ```javascript
@@ -270,6 +281,7 @@ For every primitive type in q, this module exports a method to wrap the JavaScri
 	* `unixSocket`: String (e. g. "/path/to/socket") (optional)
 	* `user`: String (optional)
 	* `password`: String (optional)
+	* `useTLS`: Boolean (optional)
 	* `socketNoDelay` : Boolean (optional, see http://nodejs.org/api/net.html#net_socket_setnodelay_nodelay)
 	* `socketTimeout`: Number (optional, see http://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback)
 	* `nanos2date`: Boolean (optional, default: true)

--- a/index.js
+++ b/index.js
@@ -230,6 +230,9 @@ function connect(params, cb) {
 		if (error === false) {
 			socket.once("close", closecb);
 			var con = new Connection(socket, params.nanos2date, params.flipTables, params.emptyChar2null, params.long2number);
+			con.once("error", function(err) {
+				cb(err)
+			})
 			con.auth(auth, function() {
 				socket.removeListener("close", closecb);
 				if (close === false) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var libc = require("./lib/c.js");
 var net = require("net");
+var tls = require("tls");
 var events = require("events");
 var util = require("util");
 var assert = require("./lib/assert.js");
 var typed = require("./lib/typed.js");
+const { TLSSocket } = require("tls");
 
 function Connection(socket, nanos2date, flipTables, emptyChar2null, long2number) {
 	"use strict";
@@ -203,6 +205,7 @@ function connect(params, cb) {
 	assert.optionalBool(params.emptyChar2null, "params.emptyChar2null");
 	assert.optionalBool(params.long2number, "params.long2number");
 	assert.optionalString(params.unixSocket, "params.unixSocket");
+	assert.optionalBool(params.useTLS, "params.useTLS");
 	if (params.user !== undefined) {
 		assert.string(params.password, "password");
 		auth = params.user + ":" + params.password;
@@ -241,7 +244,16 @@ function connect(params, cb) {
 			});
 		}
 	});
-	socket = net.connect.apply(null, socketArgs);
+
+	if (params.useTLS) {
+		console.log("using TLS")
+		
+		socket = tls.connect.apply(null, socketArgs)
+	} else {
+		console.log("NO TLS")
+		socket = net.connect.apply(null, socketArgs)
+	}
+	
 	if (params.socketTimeout !== undefined) {
 		socket.setTimeout(params.socketTimeout);
 	}

--- a/index.js
+++ b/index.js
@@ -234,6 +234,7 @@ function connect(params, cb) {
 			socket.once("close", closecb);
 			var con = new Connection(socket, params.nanos2date, params.flipTables, params.emptyChar2null, params.long2number);
 			con.once("error", function(err) {
+				socket.removeListener("close", closecb);
 				cb(err)
 			})
 			con.auth(auth, function() {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var events = require("events");
 var util = require("util");
 var assert = require("./lib/assert.js");
 var typed = require("./lib/typed.js");
-const { TLSSocket } = require("tls");
 
 function Connection(socket, nanos2date, flipTables, emptyChar2null, long2number) {
 	"use strict";

--- a/index.js
+++ b/index.js
@@ -245,12 +245,9 @@ function connect(params, cb) {
 		}
 	});
 
-	if (params.useTLS) {
-		console.log("using TLS")
-		
+	if (params.useTLS) {		
 		socket = tls.connect.apply(null, socketArgs)
 	} else {
-		console.log("NO TLS")
 		socket = net.connect.apply(null, socketArgs)
 	}
 	

--- a/itest/tls.js
+++ b/itest/tls.js
@@ -16,4 +16,11 @@ describe("tls", function() {
       done()
     });
   })
+
+  it("should fail if useTLS is true and endpoint doesn't expect it", function(done) {
+    nodeq.connect({host: "localhost", port: 5000, useTLS: true}, function(err) {
+      assert.ok(err)
+      done()
+    });
+  })
 });

--- a/itest/tls.js
+++ b/itest/tls.js
@@ -1,0 +1,19 @@
+var nodeq = require("../index.js"),
+    assert = require("assert")
+
+describe("tls", function() {
+	"use strict"
+  it("should fail if endpoint expects tls and we don't set useTLS to true", function(done) {
+    nodeq.connect({host: "localhost", port: 6000}, function(err) {
+      assert.ok(err)
+      done()
+    });
+  });
+  
+  it("should connect successfully if useTLS is true", function(done) {
+    nodeq.connect({host: "localhost", port: 6000, useTLS: true}, function(err) {
+      if (err) { throw err }
+      done()
+    });
+  })
+});


### PR DESCRIPTION
This both adds support for a useTLS parameter that will then make the library create a TLSSocket as opposed to a normal net.Socket. It also adds an extra one time error handler on the Connection instance before attempting auth to catch an ECONNRESET error that is thrown when attempting to connect to a TLS only kdb server without using a TLS Socket.

I'm happy to try and add tests for this but wasn't sure of the best way to create a test server for it in the test suite. In my tests I used self signed certificates but I had to temporarily override the security settings to get node to allow that.